### PR TITLE
feat: add catchall error page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.42.1",
-        "react-router-dom": "^6.6.1",
+        "react-router-dom": "^6.10.0",
         "zustand": "^4.1.5"
       },
       "devDependencies": {
@@ -1208,9 +1208,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.1.tgz",
-      "integrity": "sha512-+eun1Wtf72RNRSqgU7qM2AMX/oHp+dnx7BHk1qhK5ZHzdHTUU4LA1mGG1vT+jMc8sbhG3orvsfOmryjzx2PzQw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.5.0.tgz",
+      "integrity": "sha512-bkUDCp8o1MvFO+qxkODcbhSqRa6P2GXgrGZVpt0dCXNW2HCSCqYI0ZoAqEOSAjRWmmlKcYgFvN4B4S+zo/f8kg==",
       "engines": {
         "node": ">=14"
       }
@@ -1926,11 +1926,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.0.tgz",
-      "integrity": "sha512-760bk7y3QwabduExtudhWbd88IBbuD1YfwzpuDUAlJUJ7laIIcqhMvdhSVh1Fur1PE8cGl84L0dxhR3/gvHF7A==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.10.0.tgz",
+      "integrity": "sha512-Nrg0BWpQqrC3ZFFkyewrflCud9dio9ME3ojHCF/WLsprJVzkq3q3UeEhMCAW1dobjeGbWgjNn/PVF6m46ANxXQ==",
       "dependencies": {
-        "@remix-run/router": "1.3.1"
+        "@remix-run/router": "1.5.0"
       },
       "engines": {
         "node": ">=14"
@@ -1940,12 +1940,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.0.tgz",
-      "integrity": "sha512-hQouduSTywGJndE86CXJ2h7YEy4HYC6C/uh19etM+79FfQ6cFFFHnHyDlzO4Pq0eBUI96E4qVE5yUjA00yJZGQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.10.0.tgz",
+      "integrity": "sha512-E5dfxRPuXKJqzwSe/qGcqdwa18QiWC6f3H3cWXM24qj4N0/beCIf/CWTipop2xm7mR0RCS99NnaqPNjHtrAzCg==",
       "dependencies": {
-        "@remix-run/router": "1.3.1",
-        "react-router": "6.8.0"
+        "@remix-run/router": "1.5.0",
+        "react-router": "6.10.0"
       },
       "engines": {
         "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.42.1",
-    "react-router-dom": "^6.6.1",
+    "react-router-dom": "^6.10.0",
     "zustand": "^4.1.5"
   },
   "devDependencies": {

--- a/src/components/default-error-page/default-error-page.tsx
+++ b/src/components/default-error-page/default-error-page.tsx
@@ -1,0 +1,67 @@
+import { Box, Stack, Typography } from "@mui/material";
+import { isRouteErrorResponse, useRouteError } from "react-router-dom";
+import { theme } from "../../lib";
+import { IntrospectionError } from "../../state/introspection";
+
+function DefaultErrorPage() {
+  const error = useRouteError();
+
+  if (isRouteErrorResponse(error)) {
+    if (error.status === 404) {
+      return (
+        <Typography component="code">
+          Die Seite wurde nicht gefunden.
+        </Typography>
+      );
+    }
+
+    return (
+      <Typography component="code">
+        Ein komischer Routing-Fehler: {error.statusText}
+      </Typography>
+    );
+  }
+
+  if (error instanceof IntrospectionError) {
+    return (
+      <Stack p={2}>
+        <Typography variant="h3" fontWeight="bold">
+          Debug error thrown:
+        </Typography>
+        <Typography fontSize="1.2rem" component="code">
+          <b>{error.name}</b>: {error.message}
+        </Typography>
+      </Stack>
+    );
+  }
+
+  if (error instanceof Error) {
+    return (
+      <Stack p={2}>
+        <Typography variant="h3" fontWeight="bold">
+          Etwas ist schiefgelaufen:
+        </Typography>
+        <Typography fontSize="1.2rem" component="code">
+          <b>{error.name}</b>: {error.message}
+        </Typography>
+
+        <Box mt={2} p={1} bgcolor={theme.palette.grey.A400}>
+          <Typography color={theme.palette.grey.A700} component="code">
+            {error.stack}
+          </Typography>
+        </Box>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack>
+      <Typography>Etwas ist schiefgelaufen:</Typography>
+      {typeof error === "object" && (
+        <Typography component="code">{JSON.stringify(error)}</Typography>
+      )}
+    </Stack>
+  );
+}
+
+export default DefaultErrorPage;

--- a/src/components/default-error-page/index.ts
+++ b/src/components/default-error-page/index.ts
@@ -1,0 +1,1 @@
+export { default } from './default-error-page';

--- a/src/components/error-aware-routes/error-aware-routes.tsx
+++ b/src/components/error-aware-routes/error-aware-routes.tsx
@@ -1,0 +1,43 @@
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  PropsWithChildren,
+  ReactElement,
+} from "react";
+import { Route, RouteProps, Routes } from "react-router-dom";
+import DefaultErrorPage from "../default-error-page";
+
+type ErrorAwareRoutesProps = PropsWithChildren;
+
+/**
+ * Determines if the element is a Route from react-router-dom.
+ * @param element - the element in question.
+ */
+function isElementRoute(element: unknown): element is ReactElement<RouteProps> {
+  return isValidElement(element) && element.type === Route;
+}
+
+/**
+ * There is this stupid bug from react-router where error won't bubble up through
+ * Routes components: https://github.com/remix-run/react-router/issues/10021
+ *
+ * This is why we simply clone each element and attach a default handler if nothing
+ * has been attached, yet.
+ */
+function ErrorAwareRoutes({ children }: ErrorAwareRoutesProps) {
+  return (
+    <Routes>
+      {Children.map(children, (child) => {
+        if (isElementRoute(child) && !child?.props?.errorElement) {
+          return cloneElement(child as ReactElement<RouteProps>, {
+            errorElement: <DefaultErrorPage />,
+          });
+        }
+        return child;
+      })}
+    </Routes>
+  );
+}
+
+export default ErrorAwareRoutes;

--- a/src/components/error-aware-routes/index.ts
+++ b/src/components/error-aware-routes/index.ts
@@ -1,0 +1,1 @@
+export { default } from './error-aware-routes';

--- a/src/features/admin/hooks/use-assignment-query.ts
+++ b/src/features/admin/hooks/use-assignment-query.ts
@@ -1,9 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { Assignment } from "../../order/types/assignment";
+import { introspect } from "../../../state/introspection";
 
-function getAssignment(assignmentId: number): Promise<Assignment> {
-  return fetch(`/api/assignment/${assignmentId}`).then((res) => res.json());
-}
+const getAssignment = introspect(
+  "Get an assignment",
+  (assignmentId: number): Promise<Assignment> =>
+    fetch(`/api/assignment/${assignmentId}`).then((res) => res.json())
+);
 
 export function useAssignmentQuery(assignmentId: number) {
   return useQuery({

--- a/src/features/admin/hooks/use-create-admin-mutation.ts
+++ b/src/features/admin/hooks/use-create-admin-mutation.ts
@@ -1,16 +1,17 @@
 import { useMutation, UseMutationOptions } from "@tanstack/react-query";
 import { CreateItemInput, Option, Variant } from "../types/table-data";
 import { Assignment } from "../../order/types/assignment";
+import { introspect } from "../../../state/introspection";
 
-function createOption(option: Option) {
-  return fetch(`/api/option`, {
+const createOption = introspect("Create an option", (option: Option) =>
+  fetch(`/api/option`, {
     method: "post",
     body: JSON.stringify(option),
     headers: {
       "content-type": "application/json",
     },
-  });
-}
+  })
+);
 
 export function useCreateOptionMutation(
   options: UseMutationOptions<unknown, unknown, Option>
@@ -21,15 +22,15 @@ export function useCreateOptionMutation(
   });
 }
 
-function createItem(item: CreateItemInput) {
-  return fetch(`/api/item`, {
+const createItem = introspect("Create an item", (item: CreateItemInput) =>
+  fetch(`/api/item`, {
     method: "post",
     body: JSON.stringify(item),
     headers: {
       "content-type": "application/json",
     },
-  });
-}
+  })
+);
 
 export function useCreateItemMutation(
   options: UseMutationOptions<unknown, unknown, CreateItemInput>
@@ -40,15 +41,15 @@ export function useCreateItemMutation(
   });
 }
 
-function createVariant(variant: Variant) {
-  return fetch(`/api/variant`, {
+const createVariant = introspect("Create a variant", (variant: Variant) =>
+  fetch(`/api/variant`, {
     method: "post",
     body: JSON.stringify(variant),
     headers: {
       "content-type": "application/json",
     },
-  });
-}
+  })
+);
 
 export function useCreateVariantMutation(
   options: UseMutationOptions<unknown, unknown, Variant>
@@ -59,15 +60,17 @@ export function useCreateVariantMutation(
   });
 }
 
-function createAssignment(assignment: Assignment) {
-  return fetch(`/api/assignment`, {
-    method: "post",
-    body: JSON.stringify(assignment),
-    headers: {
-      "content-type": "application/json",
-    },
-  });
-}
+const createAssignment = introspect(
+  "Create an assignment",
+  (assignment: Assignment) =>
+    fetch(`/api/assignment`, {
+      method: "post",
+      body: JSON.stringify(assignment),
+      headers: {
+        "content-type": "application/json",
+      },
+    })
+);
 
 export function useCreateAssignmentMutation(
   options: UseMutationOptions<unknown, unknown, Assignment>

--- a/src/features/admin/hooks/use-create-item-data-query.ts
+++ b/src/features/admin/hooks/use-create-item-data-query.ts
@@ -1,13 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
 import { ItemData } from "../types/table-data";
+import { introspect } from "../../../state/introspection";
 
-function getItem(itemId: number): Promise<ItemData> {
-  if (itemId != 0) {
-    return fetch(`/api/item-creation-data/${itemId}`).then((res) => res.json());
-  } else {
-    return fetch(`/api/item-creation-data`).then((res) => res.json());
+const getItem = introspect(
+  "Get item creation data",
+  (itemId: number): Promise<ItemData> => {
+    if (itemId != 0) {
+      return fetch(`/api/item-creation-data/${itemId}`).then((res) =>
+        res.json()
+      );
+    } else {
+      return fetch(`/api/item-creation-data`).then((res) => res.json());
+    }
   }
-}
+);
 
 export function useCreateItemDataQuery(itemId: number) {
   return useQuery({

--- a/src/features/admin/hooks/use-delete-admin-mutation.ts
+++ b/src/features/admin/hooks/use-delete-admin-mutation.ts
@@ -1,11 +1,12 @@
 import { useMutation, UseMutationOptions } from "@tanstack/react-query";
+import { introspect } from "../../../state/introspection";
 
-function deleteOption(optionId: number) {
-  return fetch(`/api/option/${optionId}`, {
+const deleteOption = introspect("Delete an option", (optionId: number) =>
+  fetch(`/api/option/${optionId}`, {
     method: "delete",
     headers: {},
-  });
-}
+  })
+);
 
 export function useDeleteOptionMutation(
   options: UseMutationOptions<unknown, unknown, number>
@@ -16,12 +17,14 @@ export function useDeleteOptionMutation(
   });
 }
 
-function deleteAssignment(assignmentId: number) {
-  return fetch(`/api/assignment/${assignmentId}`, {
-    method: "delete",
-    headers: {},
-  });
-}
+const deleteAssignment = introspect(
+  "Delete an assignment",
+  (assignmentId: number) =>
+    fetch(`/api/assignment/${assignmentId}`, {
+      method: "delete",
+      headers: {},
+    })
+);
 
 export function useDeleteAssignmentMutation(
   options: UseMutationOptions<unknown, unknown, number>
@@ -32,12 +35,12 @@ export function useDeleteAssignmentMutation(
   });
 }
 
-function deleteItem(itemId: number) {
-  return fetch(`/api/item/${itemId}`, {
+const deleteItem = introspect("Delete item", (itemId: number) =>
+  fetch(`/api/item/${itemId}`, {
     method: "delete",
     headers: {},
-  });
-}
+  })
+);
 
 export function useDeleteItemMutation(
   options: UseMutationOptions<unknown, unknown, number>
@@ -48,12 +51,12 @@ export function useDeleteItemMutation(
   });
 }
 
-function deleteVariant(variantId: number) {
-  return fetch(`/api/variant/${variantId}`, {
+const deleteVariant = introspect("Delete a variant", (variantId: number) =>
+  fetch(`/api/variant/${variantId}`, {
     method: "delete",
     headers: {},
-  });
-}
+  })
+);
 
 export function useDeleteVariantMutation(
   options: UseMutationOptions<unknown, unknown, number>

--- a/src/features/admin/hooks/use-option-query.ts
+++ b/src/features/admin/hooks/use-option-query.ts
@@ -1,9 +1,12 @@
 import { Option } from "../types/table-data";
 import { useQuery } from "@tanstack/react-query";
+import { introspect } from "../../../state/introspection";
 
-function getOption(optionId: number): Promise<Option> {
-  return fetch(`/api/option/${optionId}`).then((res) => res.json());
-}
+const getOption = introspect(
+  "Get an option",
+  (optionId: number): Promise<Option> =>
+    fetch(`/api/option/${optionId}`).then((res) => res.json())
+);
 
 export function useOptionQuery(optionId: number) {
   return useQuery({

--- a/src/features/admin/hooks/use-table-query.ts
+++ b/src/features/admin/hooks/use-table-query.ts
@@ -1,9 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { TableData } from "../types/table-data";
+import { introspect } from "../../../state/introspection";
 
-function getTables(): Promise<TableData> {
-  return fetch("/api/table-data").then((res) => res.json());
-}
+const getTables = introspect(
+  "Get admin table data",
+  (): Promise<TableData> => fetch("/api/table-data").then((res) => res.json())
+);
 
 export const tableDataQueryOptions = {
   queryKey: ["table-data"],

--- a/src/features/admin/hooks/use-update-admin-mutation.ts
+++ b/src/features/admin/hooks/use-update-admin-mutation.ts
@@ -1,8 +1,9 @@
 import { useMutation, UseMutationOptions } from "@tanstack/react-query";
 import { ItemData, Option, Variant } from "../types/table-data";
 import { Assignment } from "../../order/types/assignment";
+import { introspect } from "../../../state/introspection";
 
-function updateOption(option: Option) {
+const updateOption = introspect("Update an option", (option: Option) => {
   const optionId = option.id;
   return fetch(`/api/option/${optionId}`, {
     method: "put",
@@ -11,7 +12,7 @@ function updateOption(option: Option) {
       "content-type": "application/json",
     },
   });
-}
+});
 
 export function useUpdateOptionMutation(
   options: UseMutationOptions<unknown, unknown, Option>
@@ -22,7 +23,7 @@ export function useUpdateOptionMutation(
   });
 }
 
-function updateItem(item: ItemData) {
+const updateItem = introspect("Update an item", (item: ItemData) => {
   const itemId = item.itemId;
   return fetch(`/api/item/${itemId}`, {
     method: "put",
@@ -31,7 +32,7 @@ function updateItem(item: ItemData) {
       "content-type": "application/json",
     },
   });
-}
+});
 
 export function useUpdateItemMutation(
   options: UseMutationOptions<unknown, unknown, ItemData>
@@ -42,7 +43,7 @@ export function useUpdateItemMutation(
   });
 }
 
-function updateVariant(variant: Variant) {
+const updateVariant = introspect("Update a variant", (variant: Variant) => {
   const variantId = variant.variantGroup.id;
   return fetch(`/api/variant/${variantId}`, {
     method: "put",
@@ -51,7 +52,7 @@ function updateVariant(variant: Variant) {
       "content-type": "application/json",
     },
   });
-}
+});
 
 export function useUpdateVariantMutation(
   options: UseMutationOptions<unknown, unknown, Variant>
@@ -62,7 +63,7 @@ export function useUpdateVariantMutation(
   });
 }
 
-function updateAssignment(assignment: Assignment) {
+const updateAssignment = introspect("Update an assignment", (assignment: Assignment) => {
   const assignmentId = assignment.id;
   return fetch(`/api/assignment/${assignmentId}`, {
     method: "put",
@@ -71,7 +72,7 @@ function updateAssignment(assignment: Assignment) {
       "content-type": "application/json",
     },
   });
-}
+});
 
 export function useUpdateAssignmentMutation(
   options: UseMutationOptions<unknown, unknown, Assignment>

--- a/src/features/admin/hooks/use-variant-query.ts
+++ b/src/features/admin/hooks/use-variant-query.ts
@@ -1,15 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
 import { Variant } from "../types/table-data";
 import { idSort } from "../../../utils/id-sort";
+import { introspect } from "../../../state/introspection";
 
-async function getVariant(variantId: number): Promise<Variant> {
-  const res = await fetch(`/api/variant/${variantId}`);
-  const variant = (await res.json()) as Variant;
-  return {
-    ...variant,
-    singleVariants: variant.singleVariants.sort(idSort),
-  };
-}
+const getVariant = introspect(
+  "Get a variant",
+  async (variantId: number): Promise<Variant> => {
+    const res = await fetch(`/api/variant/${variantId}`);
+    const variant = (await res.json()) as Variant;
+    return {
+      ...variant,
+      singleVariants: variant.singleVariants.sort(idSort),
+    };
+  }
+);
 
 export function useVariantQuery(variantId: number) {
   return useQuery({

--- a/src/features/admin/routes/routes.tsx
+++ b/src/features/admin/routes/routes.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import { Route, Routes } from "react-router-dom";
+import { Route } from "react-router-dom";
 import Admin from "./admin";
 import CreateOption from "./option/create-option";
 import EditOption from "./option/edit-option";
@@ -9,11 +9,12 @@ import EditItem from "./item/edit-item";
 import EditVariant from "./variant/edit-variant";
 import CreateVariant from "./variant/create-variant";
 import CreateItem from "./item/create-item";
+import ErrorAwareRoutes from "../../../components/error-aware-routes";
 
 function AdminRoutes() {
   return (
     <Suspense fallback="Laden...">
-      <Routes>
+      <ErrorAwareRoutes>
         <Route path="option/:optionId" element={<EditOption />} />
         <Route path="option/new" element={<CreateOption />} />
 
@@ -27,7 +28,7 @@ function AdminRoutes() {
         <Route path="item/new" element={<CreateItem />} />
 
         <Route index element={<Admin />} />
-      </Routes>
+      </ErrorAwareRoutes>
     </Suspense>
   );
 }

--- a/src/features/order/hooks/use-assignments-query.ts
+++ b/src/features/order/hooks/use-assignments-query.ts
@@ -1,13 +1,14 @@
 import { useQuery, UseQueryOptions } from "@tanstack/react-query";
 import { Assignment } from "../types/assignment";
+import { introspect } from "../../../state/introspection";
 
-function getAssignments(): Promise<Assignment[]> {
+const getAssignments = introspect("List all assignments", () => {
   return fetch("/api/assignments")
     .then((res) => res.json())
     .then((res: Record<"assignments", Assignment[]>) =>
       res.assignments.sort((a, b) => a.id - b.id)
     );
-}
+});
 
 export const assignmentsQueryOptions = {
   queryKey: ["assignments"],

--- a/src/features/order/hooks/use-configuration-query.ts
+++ b/src/features/order/hooks/use-configuration-query.ts
@@ -1,9 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { Configuration } from "../types/configuration";
+import { introspect } from "../../../state/introspection";
 
-function getConfiguration(itemId: string): Promise<Configuration> {
-  return fetch(`/api/item/${itemId}/configuration`).then((res) => res.json());
-}
+const getConfiguration = introspect(
+  "Get an item config",
+  (itemId: string): Promise<Configuration> =>
+    fetch(`/api/item/${itemId}/configuration`).then((res) => res.json())
+);
 
 export default function useConfigurationQuery(itemId: string) {
   return useQuery({

--- a/src/features/order/hooks/use-create-round-mutation.ts
+++ b/src/features/order/hooks/use-create-round-mutation.ts
@@ -1,17 +1,21 @@
 import { useMutation, UseMutationOptions } from "@tanstack/react-query";
 import { Round } from "../types/round";
+import { introspect } from "../../../state/introspection";
 
-function createRound({ assignmentId, orderedItems }: Round) {
-  const url = `/api/assignment/${assignmentId}/current-order/round`;
+const createRound = introspect(
+  "Create a round in current order",
+  ({ assignmentId, orderedItems }: Round) => {
+    const url = `/api/assignment/${assignmentId}/current-order/round`;
 
-  return fetch(url, {
-    method: "post",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(orderedItems),
-  });
-}
+    return fetch(url, {
+      method: "post",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(orderedItems),
+    });
+  }
+);
 
 export function useCreateRoundMutation(
   options: UseMutationOptions<unknown, unknown, Round>

--- a/src/features/order/hooks/use-items-query.ts
+++ b/src/features/order/hooks/use-items-query.ts
@@ -1,13 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 import { Item } from "../types/item";
+import { introspect } from "../../../state/introspection";
 
-function getItems(): Promise<Item[]> {
-  return fetch("/api/items")
-    .then((res) => res.json())
-    .then((res: Record<"items", Item[]>) =>
-      res.items.sort((a, b) => a.id - b.id)
-    );
-}
+const getItems = introspect(
+  "Get all items",
+  (): Promise<Item[]> =>
+    fetch("/api/items")
+      .then((res) => res.json())
+      .then((res: Record<"items", Item[]>) =>
+        res.items.sort((a, b) => a.id - b.id)
+      )
+);
 
 export const itemsQueryOptions = {
   queryKey: [],

--- a/src/features/order/routes/assignment-control.tsx
+++ b/src/features/order/routes/assignment-control.tsx
@@ -5,16 +5,17 @@ import { useMutation } from "@tanstack/react-query";
 import { Assignment } from "../types/assignment";
 import { Typography } from "@mui/material";
 import { useActiveAssignment } from "../hooks/use-active-assignment";
+import { introspect } from "../../../state/introspection";
 
-function createOrder(assignment: Assignment) {
-  return fetch("/api/order", {
+const createOrder = introspect("Create new order", (assignment: Assignment) =>
+  fetch("/api/order", {
     body: JSON.stringify({ assignment }),
     method: "post",
     headers: {
       "content-type": "application/json",
     },
-  });
-}
+  })
+);
 
 function AssignmentControl() {
   const assignment = useActiveAssignment();

--- a/src/features/order/routes/routes.tsx
+++ b/src/features/order/routes/routes.tsx
@@ -1,15 +1,16 @@
-import { Route, Routes } from "react-router-dom";
+import { Route } from "react-router-dom";
 import Assignments from "./assignments";
 import Items from "./items";
 import Overview from "./overview";
 import Configurator from "./configurator";
 import { Suspense } from "react";
 import AssignmentControl from "./assignment-control";
+import ErrorAwareRoutes from "../../../components/error-aware-routes";
 
 function OrderRoutes() {
   return (
     <Suspense fallback="Laden...">
-      <Routes>
+      <ErrorAwareRoutes>
         <Route path=":assignmentId" element={<AssignmentControl />}>
           <Route path="items">
             <Route index element={<Items />} />
@@ -18,7 +19,7 @@ function OrderRoutes() {
           <Route path="overview" element={<Overview />} />
         </Route>
         <Route index element={<Assignments />} />
-      </Routes>
+      </ErrorAwareRoutes>
     </Suspense>
   );
 }

--- a/src/features/round-overview/hooks/use-open-rounds-query.ts
+++ b/src/features/round-overview/hooks/use-open-rounds-query.ts
@@ -4,36 +4,37 @@ import {
   UseQueryOptions,
 } from "@tanstack/react-query";
 import { SortedRound, UnpreparedRound } from "../types";
+import { introspect } from "../../../state/introspection";
 
-function fetchOpenRounds({
-  signal,
-}: QueryFunctionContext): Promise<SortedRound[]> {
-  return fetch("/api/round?status=unprepared", {
-    signal,
-  })
-    .then((res) => res.json())
-    .then((res: UnpreparedRound[]) =>
-      res
-        .map((value) => ({
-          id: value.id,
-          orderedAt: value.orderedAt,
-          orderedBy: value.orderedBy,
-          orderedItemsByCategory: value.orderedItems.reduce(
-            (previousValue, currentValue) => {
-              previousValue[currentValue.category.name] = (
-                previousValue[currentValue.category.name] || []
-              ).concat(currentValue);
-              return previousValue;
-            },
-            {} as SortedRound["orderedItemsByCategory"]
-          ),
-        }))
-        .sort(
-          (a, b) =>
-            new Date(a.orderedAt).getTime() - new Date(b.orderedAt).getTime()
-        )
-    );
-}
+const fetchOpenRounds = introspect(
+  "Fetch unprepared rounds",
+  ({ signal }: QueryFunctionContext): Promise<SortedRound[]> =>
+    fetch("/api/round?status=unprepared", {
+      signal,
+    })
+      .then((res) => res.json())
+      .then((res: UnpreparedRound[]) =>
+        res
+          .map((value) => ({
+            id: value.id,
+            orderedAt: value.orderedAt,
+            orderedBy: value.orderedBy,
+            orderedItemsByCategory: value.orderedItems.reduce(
+              (previousValue, currentValue) => {
+                previousValue[currentValue.category.name] = (
+                  previousValue[currentValue.category.name] || []
+                ).concat(currentValue);
+                return previousValue;
+              },
+              {} as SortedRound["orderedItemsByCategory"]
+            ),
+          }))
+          .sort(
+            (a, b) =>
+              new Date(a.orderedAt).getTime() - new Date(b.orderedAt).getTime()
+          )
+      )
+);
 
 export function useOpenRoundsQuery(options: UseQueryOptions<SortedRound[]>) {
   return useQuery({

--- a/src/features/round-overview/hooks/use-prepare-round-mutation.ts
+++ b/src/features/round-overview/hooks/use-prepare-round-mutation.ts
@@ -1,14 +1,17 @@
 import { useMutation, UseMutationOptions } from "@tanstack/react-query";
+import { introspect } from "../../../state/introspection";
 
-function updateMarkRoundAsPrepared(roundId: number) {
-  return fetch(`/api/round/${roundId}/state`, {
-    method: "put",
-    body: JSON.stringify({ state: "PREPARED" }),
-    headers: {
-      "content-type": "application/json",
-    },
-  });
-}
+const updateMarkRoundAsPrepared = introspect(
+  "Mark round as prepared",
+  (roundId: number) =>
+    fetch(`/api/round/${roundId}/state`, {
+      method: "put",
+      body: JSON.stringify({ state: "PREPARED" }),
+      headers: {
+        "content-type": "application/json",
+      },
+    })
+);
 
 export function usePrepareRoundMutation(
   options: UseMutationOptions<unknown, unknown, number>

--- a/src/hooks/use-appconfig-query.ts
+++ b/src/hooks/use-appconfig-query.ts
@@ -1,0 +1,15 @@
+import { introspect } from "../state/introspection";
+import { useQuery } from "@tanstack/react-query";
+import { AppConfig } from "../types/app-config";
+
+const getAppConfig = introspect(
+  "Get an assignment",
+  (): Promise<AppConfig> => fetch(`/api/appconfig`).then((res) => res.json())
+);
+
+export function useAppConfigQuery() {
+  return useQuery({
+    queryKey: ["appconfig"],
+    queryFn: () => getAppConfig(),
+  });
+}

--- a/src/hooks/use-appconfig-query.ts
+++ b/src/hooks/use-appconfig-query.ts
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { AppConfig } from "../types/app-config";
 
 const getAppConfig = introspect(
-  "Get an assignment",
+  "Get the app config",
   (): Promise<AppConfig> => fetch(`/api/appconfig`).then((res) => res.json())
 );
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,9 @@ import "@fontsource/roboto/300.css";
 import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/500.css";
 import "@fontsource/roboto/700.css";
-import React, { Suspense, useMemo } from "react";
+import React, { Suspense } from "react";
 import ReactDOM from "react-dom/client";
-import { createBrowserRouter, Outlet, RouterProvider } from "react-router-dom";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { ThemeProvider } from "./providers";
 import { Landing } from "./features/landing";
 import { OrderRoutes } from "./features/order";
@@ -13,61 +13,7 @@ import { RoundOverview } from "./features/round-overview";
 import { queryClient } from "./lib";
 import AdminRoutes from "./features/admin/routes/routes";
 import DefaultErrorPage from "./components/default-error-page";
-import { useIntrospectionStore } from "./state/introspection";
-import {
-  Box,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
-  SelectChangeEvent,
-} from "@mui/material";
-import { invariant } from "./utils/invariant";
-
-function Root() {
-  const { registeredFunctions, setFunctionToFail } = useIntrospectionStore();
-
-  const functionSymbolIndex = useMemo(() => {
-    return registeredFunctions.reduce(
-      (prev, curr) => ({
-        ...prev,
-        [curr.description!]: curr,
-      }),
-      {} as Record<string, Symbol>
-    );
-  }, [registeredFunctions]);
-
-  const handleOperationChange = (event: SelectChangeEvent) => {
-    const value = event.target.value;
-    const symbol = functionSymbolIndex[value];
-    invariant(symbol, "function symbol not in index");
-    setFunctionToFail(symbol);
-  };
-
-  return (
-    <>
-      <Box position="fixed" right={0} bottom={0}>
-        <FormControl>
-          <InputLabel id="debug-operation">Operation</InputLabel>
-          <Select
-            onChange={handleOperationChange}
-            defaultValue=""
-            labelId="debug-operation"
-            label="Operation"
-            autoWidth
-          >
-            {registeredFunctions.map((func) => (
-              <MenuItem key={func.description} value={func.description}>
-                {func.description}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-      </Box>
-      <Outlet />
-    </>
-  );
-}
+import Root from "./root";
 
 const router = createBrowserRouter([
   {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,9 @@ import "@fontsource/roboto/300.css";
 import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/500.css";
 import "@fontsource/roboto/700.css";
-import React, { Suspense } from "react";
+import React, { Suspense, useMemo } from "react";
 import ReactDOM from "react-dom/client";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { createBrowserRouter, Outlet, RouterProvider } from "react-router-dom";
 import { ThemeProvider } from "./providers";
 import { Landing } from "./features/landing";
 import { OrderRoutes } from "./features/order";
@@ -12,23 +12,86 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { RoundOverview } from "./features/round-overview";
 import { queryClient } from "./lib";
 import AdminRoutes from "./features/admin/routes/routes";
+import DefaultErrorPage from "./components/default-error-page";
+import { useIntrospectionStore } from "./state/introspection";
+import {
+  Box,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+} from "@mui/material";
+import { invariant } from "./utils/invariant";
+
+function Root() {
+  const { registeredFunctions, setFunctionToFail } = useIntrospectionStore();
+
+  const functionSymbolIndex = useMemo(() => {
+    return registeredFunctions.reduce(
+      (prev, curr) => ({
+        ...prev,
+        [curr.description!]: curr,
+      }),
+      {} as Record<string, Symbol>
+    );
+  }, [registeredFunctions]);
+
+  const handleOperationChange = (event: SelectChangeEvent) => {
+    const value = event.target.value;
+    const symbol = functionSymbolIndex[value];
+    invariant(symbol, "function symbol not in index");
+    setFunctionToFail(symbol);
+  };
+
+  return (
+    <>
+      <Box position="fixed" right={0} bottom={0}>
+        <FormControl>
+          <InputLabel id="debug-operation">Operation</InputLabel>
+          <Select
+            onChange={handleOperationChange}
+            defaultValue=""
+            labelId="debug-operation"
+            label="Operation"
+            autoWidth
+          >
+            {registeredFunctions.map((func) => (
+              <MenuItem key={func.description} value={func.description}>
+                {func.description}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+      <Outlet />
+    </>
+  );
+}
 
 const router = createBrowserRouter([
   {
     path: "/",
-    element: <Landing />,
-  },
-  {
-    path: "/assignments/*",
-    element: <OrderRoutes />,
-  },
-  {
-    path: "/round-overview",
-    element: <RoundOverview />,
-  },
-  {
-    path: "/admin/*",
-    element: <AdminRoutes />,
+    element: <Root />,
+    errorElement: <DefaultErrorPage />,
+    children: [
+      {
+        index: true,
+        element: <Landing />,
+      },
+      {
+        path: "/assignments/*",
+        element: <OrderRoutes />,
+      },
+      {
+        path: "/round-overview",
+        element: <RoundOverview />,
+      },
+      {
+        path: "/admin/*",
+        element: <AdminRoutes />,
+      },
+    ],
   },
 ]);
 

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -1,0 +1,88 @@
+import { useIntrospectionStore } from "./state/introspection";
+import { invariant } from "./utils/invariant";
+import CancelIcon from "@mui/icons-material/Cancel";
+import {
+  Box,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+} from "@mui/material";
+import { useMemo } from "react";
+import { Outlet } from "react-router-dom";
+import { theme } from "./lib";
+import { useAppConfigQuery } from "./hooks/use-appconfig-query";
+
+function Root() {
+  const { data: config } = useAppConfigQuery();
+  const { registeredFunctions, setFunctionToFail, functionToFail } =
+    useIntrospectionStore();
+
+  // Index all registered functions/operations by their symbol for easier access.
+  const functionSymbolIndex = useMemo(() => {
+    return registeredFunctions.reduce(
+      (prev, curr) => ({
+        ...prev,
+        [curr.description!]: curr,
+      }),
+      {} as Record<string, Symbol>
+    );
+  }, [registeredFunctions]);
+
+  const handleOperationChange = (event: SelectChangeEvent) => {
+    const value = event.target.value;
+    const symbol = functionSymbolIndex[value];
+    invariant(symbol, "function symbol not in index");
+    setFunctionToFail(symbol);
+  };
+
+  const hasSelection = !!functionToFail;
+  const resetSelection = () => setFunctionToFail(null);
+
+  if (!config!.debug) {
+    return <Outlet />;
+  }
+
+  return (
+    <>
+      <Box
+        position="fixed"
+        display="flex"
+        alignItems="center"
+        right={16}
+        bottom={16}
+        zIndex={100}
+        p={2}
+        bgcolor={theme.palette.background.paper}
+      >
+        <FormControl>
+          <InputLabel id="debug-operation">Operation</InputLabel>
+          <Select
+            onChange={handleOperationChange}
+            value={functionToFail?.description ?? ""}
+            labelId="debug-operation"
+            label="Operation"
+            autoWidth
+            sx={{ minWidth: "8rem" }}
+          >
+            {registeredFunctions.map((func) => (
+              <MenuItem key={func.description} value={func.description}>
+                {func.description}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        {hasSelection && (
+          <IconButton onClick={resetSelection}>
+            <CancelIcon />
+          </IconButton>
+        )}
+      </Box>
+      <Outlet />
+    </>
+  );
+}
+
+export default Root;

--- a/src/state/introspection.ts
+++ b/src/state/introspection.ts
@@ -1,0 +1,48 @@
+import produce from "immer";
+import { create } from "zustand";
+
+export class IntrospectionError extends Error {
+  constructor(msg: string) {
+    super(msg);
+  }
+}
+
+export type IntrospectionState = {
+  registeredFunctions: Symbol[];
+  functionToFail: Symbol | null;
+  registerFunction: (target: Symbol) => void;
+  setFunctionToFail: (func: Symbol) => void;
+};
+
+export const useIntrospectionStore = create<IntrospectionState>()((set) => ({
+  registeredFunctions: [],
+  functionToFail: null,
+  registerFunction: (target: Symbol) =>
+    set(
+      produce((draft: IntrospectionState) => {
+        draft.registeredFunctions.push(target);
+      })
+    ),
+  setFunctionToFail: (func: Symbol) =>
+    set(
+      produce((draft: IntrospectionState) => {
+        draft.functionToFail = func;
+      })
+    ),
+}));
+
+export function introspect<T extends Function>(name: string, target: T): T {
+  const symbol = Symbol(`op:${name}`);
+  useIntrospectionStore.getState().registerFunction(symbol);
+
+  return ((...args: unknown[]) => {
+    const { functionToFail } = useIntrospectionStore.getState();
+    if (functionToFail === symbol) {
+      console.info(`[Introspection] Failing function '${name}' due to introspection.`)
+      return Promise.reject(
+        new IntrospectionError(`${name} failed due to introspection`)
+      );
+    }
+    return target(...args);
+  }) as unknown as T;
+}

--- a/src/state/introspection.ts
+++ b/src/state/introspection.ts
@@ -11,7 +11,7 @@ export type IntrospectionState = {
   registeredFunctions: Symbol[];
   functionToFail: Symbol | null;
   registerFunction: (target: Symbol) => void;
-  setFunctionToFail: (func: Symbol) => void;
+  setFunctionToFail: (func: Symbol | null) => void;
 };
 
 export const useIntrospectionStore = create<IntrospectionState>()((set) => ({
@@ -23,7 +23,7 @@ export const useIntrospectionStore = create<IntrospectionState>()((set) => ({
         draft.registeredFunctions.push(target);
       })
     ),
-  setFunctionToFail: (func: Symbol) =>
+  setFunctionToFail: (func: Symbol | null) =>
     set(
       produce((draft: IntrospectionState) => {
         draft.functionToFail = func;

--- a/src/types/app-config.ts
+++ b/src/types/app-config.ts
@@ -1,0 +1,3 @@
+export interface AppConfig {
+  debug: boolean;
+}


### PR DESCRIPTION
Adds basic catchall page for errors thrown during renders.

What's left (should be part of a different ticket):
* Properly handle errors from `fetch()`. Currently, responses >= 400 won't throw an exception. Maybe its worth considering `axios` here.